### PR TITLE
Fix #1 "Unable to change rate if device code is empty"

### DIFF
--- a/app/settings/templates/viewsettings.admin.xhtml
+++ b/app/settings/templates/viewsettings.admin.xhtml
@@ -23,8 +23,7 @@
             <div class="subblock">
                 <label for="scandevice">__Settings.DevicesScanDevice</label>
                 <input id="scandevice" name="ScanDeviceCode" type="number"
-                       autocomplete="off" required="required"
-                       min="0" step="any"
+                       autocomplete="off" min="0" step="any"
                        title="__Settings.DevicesDeviceCodeHint" />
             </div>
         </fieldset>


### PR DESCRIPTION
The requirement is HTML-only, no backend change required.