### PR TITLE
Implement #83: Attendee names

### DIFF
--- a/app/auction/templates/finalizeitem.admin.cz.html
+++ b/app/auction/templates/finalizeitem.admin.cz.html
@@ -18,10 +18,14 @@
     <fieldset>
         <div class="subblock">
             <label for="buyer">Kupec:</label>
-            <input id="buyer" name="NewBuyer" type="number" value="" required
-                autocomplete="off" autofocus
-                min="1" pattern="\d+"
+            <input id="buyer" name="NewBuyer" required
+                autocomplete="off" autofocus list="attendees"
                 title="Visačka kupce."/>
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </div>
         <div class="subblock">
             <input class="action" type="submit" formaction="{{sellUpdatedTarget}}"

--- a/app/auction/templates/finalizeitem.admin.de.html
+++ b/app/auction/templates/finalizeitem.admin.de.html
@@ -18,10 +18,14 @@
     <fieldset>
         <div class="subblock">
             <label for="buyer">Buyer:</label>
-            <input id="buyer" name="NewBuyer" type="number" value="" required
-                autocomplete="off" autofocus
-                min="1" pattern="\d+"
+            <input id="buyer" name="NewBuyer" required
+                autocomplete="off" autofocus list="attendees"
                 title="Buyer badge number."/>
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </div>
         <div class="subblock">
             <input class="action" type="submit" formaction="{{sellUpdatedTarget}}"

--- a/app/auction/templates/finalizeitem.admin.en.html
+++ b/app/auction/templates/finalizeitem.admin.en.html
@@ -18,10 +18,14 @@
     <fieldset>
         <div class="subblock">
             <label for="buyer">Buyer:</label>
-            <input id="buyer" name="NewBuyer" type="number" value="" required
-                autocomplete="off" autofocus
-                min="1" pattern="\d+"
+            <input id="buyer" name="NewBuyer" required
+                autocomplete="off" autofocus list="attendees"
                 title="Buyer badge number."/>
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </div>
         <div class="subblock">
             <input class="action" type="submit" formaction="{{sellUpdatedTarget}}"

--- a/app/items/templates/approveimport.admin.xhtml
+++ b/app/items/templates/approveimport.admin.xhtml
@@ -22,9 +22,14 @@
         <fieldset>
             <legend>__AdditionalInfo</legend>
             <label for="owner">__Owner:</label>
-            <input id="owner" name="Owner" type="number"
+            <input id="owner" name="Owner" list="attendees"
                    autocomplete="off" required="required"
-                   pattern="\d+" min="1" title="__OwnerHelp" />
+                   title="__OwnerHelp" />
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </fieldset>
         {%- endif %}
         <fieldset>
@@ -47,7 +52,7 @@
                     <tr>
                         <td class="{{'error' if item.IRES != 'SUCCESS' else ''}}">{{messagetext.presentShort(item.IRES)}}</td>
                         <td>{{item.NMBR if item.NMBR != None}}</td>
-                        <td>{{item.OWNR if item.OWNR != None}}</td>
+                        <td>{{item.OWNR|reg_id_to_attendee if item.OWNR != None}}</td>
                         <td>{{item.AUTH if item.AUTH != None}}</td>
                         <td>{{item.TITL if item.TITL != None}}</td>
                         <td>{{item.MEDM if item.MEDM != None}}</td>

--- a/app/items/templates/edititem.admin.cz.html
+++ b/app/items/templates/edititem.admin.cz.html
@@ -47,9 +47,14 @@
         {%- endif %}
         <fieldset>
             <label for="owner">Vlastník:</label>
-            <input id="owner" name="Owner" type="number" value="{{item.Owner|default('')}}"
+            <input id="owner" name="Owner" value="{{item.Owner|default('')}}"
                    autocomplete="off" autofocus required
-                   pattern="[1-9][0-9]*" min="1" title="Číslo visačky větší, než 1" />
+                   list="attendees" title="Číslo visačky větší, než 1" />
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </fieldset>
         <fieldset>
             <label for="author">Autor:</label>
@@ -123,9 +128,9 @@
         <fieldset>
             <div class="subblock">
                 <label for="buyer">Kupec:</label>
-                <input id="buyer" name="Buyer" type="number" value="{{item.Buyer if item.Buyer != None}}"
+                <input id="buyer" name="Buyer" value="{{item.Buyer if item.Buyer != None}}"
                        autocomplete="off"
-                       pattern="[1-9][0-9]*" min="1"
+                       list="attendees"
                        title="Číslo visačky větší, než 1" />
             </div>
             <div class="subblock">

--- a/app/items/templates/edititem.admin.de.html
+++ b/app/items/templates/edititem.admin.de.html
@@ -47,9 +47,14 @@
         {%- endif %}
         <fieldset>
             <label for="owner">Owner:</label>
-            <input id="owner" name="Owner" type="number" value="{{item.Owner|default('')}}"
-                   autocomplete="off" autofocus required
-                   pattern="[1-9][0-9]*" min="1" title="Badge number has to be greater than 1" />
+            <input id="owner" name="Owner" value="{{item.Owner|default('')}}"
+                   autocomplete="off" autofocus required list="attendees"
+                   title="Badge number has to be greater than 1" />
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </fieldset>
         <fieldset>
             <label for="author">Author:</label>
@@ -123,9 +128,8 @@
         <fieldset>
             <div class="subblock">
                 <label for="buyer">Buyer:</label>
-                <input id="buyer" name="Buyer" type="number" value="{{item.Buyer if item.Buyer != None}}"
-                       autocomplete="off"
-                       pattern="[1-9][0-9]*" min="1"
+                <input id="buyer" name="Buyer" value="{{item.Buyer if item.Buyer != None}}"
+                       autocomplete="off" list="attendees"
                        title="Badge number greater than 1" />
             </div>
             <div class="subblock">

--- a/app/items/templates/edititem.admin.en.html
+++ b/app/items/templates/edititem.admin.en.html
@@ -47,9 +47,14 @@
         {%- endif %}
         <fieldset>
             <label for="owner">Owner:</label>
-            <input id="owner" name="Owner" type="number" value="{{item.Owner|default('')}}"
+            <input id="owner" name="Owner" value="{{item.Owner|default('')}}"
                    autocomplete="off" autofocus required
-                   pattern="[1-9][0-9]*" min="1" title="Badge number has to be greater than 1" />
+                   list="attendees" title="Badge number has to be greater than 1" />
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </fieldset>
         <fieldset>
             <label for="author">Author:</label>
@@ -123,9 +128,9 @@
         <fieldset>
             <div class="subblock">
                 <label for="buyer">Buyer:</label>
-                <input id="buyer" name="Buyer" type="number" value="{{item.Buyer if item.Buyer != None}}"
+                <input id="buyer" name="Buyer" value="{{item.Buyer if item.Buyer != None}}"
                        autocomplete="off"
-                       pattern="[1-9][0-9]*" min="1"
+                       list="attendees"
                        title="Badge number greater than 1" />
             </div>
             <div class="subblock">

--- a/app/items/templates/listitems.admin.cz.html
+++ b/app/items/templates/listitems.admin.cz.html
@@ -90,7 +90,7 @@
                 <td>{{itemstate.present(item.State)}}</td>
                 <td>{{item.Author}}</td>
                 <td>{{item.Title}}</td>
-                <td class="numerical">{{item.Owner}}</td>
+                <td class="numerical">{{item.Owner|reg_id_to_attendee}}</td>
                 {% if item.InitialAmount != None and item.Charity != None -%}
                 <td class="numerical">{{item.InitialAmount}} Kč</td>
                 <td class="numerical">{{item.Charity}} %</td>
@@ -104,7 +104,7 @@
                 <td class="irrelevant"></td>
                 {%- endif %}
                 {% if item.Buyer != None -%}
-                <td class="numerical">{{item.Buyer}}</td>
+                <td class="numerical">{{item.Buyer|reg_id_to_attendee}}</td>
                 {%- else -%}
                 <td class="irrelevant"></td>
                 {%- endif %}

--- a/app/items/templates/listitems.admin.de.html
+++ b/app/items/templates/listitems.admin.de.html
@@ -89,7 +89,7 @@
                 <td>{{itemstate.present(item.State)}}</td>
                 <td>{{item.Author}}</td>
                 <td>{{item.Title}}</td>
-                <td class="numerical">{{item.Owner}}</td>
+                <td class="numerical">{{item.Owner|reg_id_to_attendee}}</td>
                 {% if item.InitialAmount != None and item.Charity != None -%}
                 <td class="numerical">{{item.InitialAmount}} €</td>
                 <td class="numerical">{{item.Charity}} %</td>
@@ -103,7 +103,7 @@
                 <td class="irrelevant"></td>
                 {%- endif %}
                 {% if item.Buyer != None -%}
-                <td class="numerical">{{item.Buyer}}</td>
+                <td class="numerical">{{item.Buyer|reg_id_to_attendee}}</td>
                 {%- else -%}
                 <td class="irrelevant"></td>
                 {%- endif %}

--- a/app/items/templates/listitems.admin.en.html
+++ b/app/items/templates/listitems.admin.en.html
@@ -89,7 +89,7 @@
                 <td>{{itemstate.present(item.State)}}</td>
                 <td>{{item.Author}}</td>
                 <td>{{item.Title}}</td>
-                <td class="numerical">{{item.Owner}}</td>
+                <td class="numerical">{{item.Owner|reg_id_to_attendee}}</td>
                 {% if item.InitialAmount != None and item.Charity != None -%}
                 <td class="numerical">{{item.InitialAmount}} €</td>
                 <td class="numerical">{{item.Charity}} %</td>
@@ -103,7 +103,7 @@
                 <td class="irrelevant"></td>
                 {%- endif %}
                 {% if item.Buyer != None -%}
-                <td class="numerical">{{item.Buyer}}</td>
+                <td class="numerical">{{item.Buyer|reg_id_to_attendee}}</td>
                 {%- else -%}
                 <td class="irrelevant"></td>
                 {%- endif %}

--- a/app/items/templates/reportimport.admin.xhtml
+++ b/app/items/templates/reportimport.admin.xhtml
@@ -30,7 +30,7 @@
                     <tr>
                         <td>{{messagetext.presentShort(item.IRES)}}</td>
                         <td>{{item.NMBR if item.NMBR != None}}</td>
-                        <td>{{item.OWNR if item.OWNR != None}}</td>
+                        <td>{{item.OWNR|reg_id_to_attendee if item.OWNR != None}}</td>
                         <td>{{item.AUTH if item.AUTH != None}}</td>
                         <td>{{item.TITL if item.TITL != None}}</td>
                         <td>{{item.MEDM if item.MEDM != None}}</td>
@@ -74,7 +74,7 @@
                     <tr>
                         <td>{{messagetext.presentShort(item.IRES)}}</td>
                         <td>{{item.NMBR if item.NMBR != None}}</td>
-                        <td>{{item.OWNR if item.OWNR != None}}</td>
+                        <td>{{item.OWNR|reg_id_to_attendee if item.OWNR != None}}</td>
                         <td>{{item.AUTH if item.AUTH != None}}</td>
                         <td>{{item.TITL if item.TITL != None}}</td>
                         <td>{{item.MEDM if item.MEDM != None}}</td>

--- a/app/items/templates/updateitemtoclose.xhtml
+++ b/app/items/templates/updateitemtoclose.xhtml
@@ -23,10 +23,14 @@
         <fieldset>
             <div class="subblock">
                 <label for="buyer"><span>__Buyer</span>:</label>
-                <input id="buyer" name="Buyer" type="number" required="required"
-                       min="1" value=""
+                <input id="buyer" name="Buyer" required="required" list="attendees"
                        autocomplete="off" autofocus="autofocus"
                        title="__BuyerHelp" />
+                <datalist id="attendees">
+                    {% for attendee in attendees %}
+                        <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                    {% endfor %}
+                </datalist>
             </div>
             <div class="subblock">
                 <label for="amount"><span>__Amount</span>:</label>

--- a/app/main.py
+++ b/app/main.py
@@ -74,6 +74,22 @@ for language in config.LANGUAGES:
                     os.path.join(dictionaryPath, 'translation.{0}.xml'.format(language))))
 del dictionaryPath
 
+
+@app.template_filter('reg_id_to_attendee')
+def reg_id_to_attendee(s):
+    """ For a given reg ID, return Attendee instance """
+    return flask.g.model.getAttendee(s)
+
+
+@app.context_processor
+def attendees():
+    """
+    get all attendees as a list. used in most templates, so use it as a
+    general context.
+    """
+    return {'attendees': flask.g.model.getAttendees()}
+
+
 @app.before_request
 def before_request():
     flask.g.userGroup = UserGroups.UNKNOWN

--- a/app/model/attendee.py
+++ b/app/model/attendee.py
@@ -1,0 +1,16 @@
+
+
+class Attendee:
+    REG_ID = 'RegId'
+    NICKNAME = 'Nickname'
+
+    ALL_PERSISTENT = sorted([REG_ID, NICKNAME])
+
+    @classmethod
+    def load(cls, d):
+        new = cls()
+        new.__dict__.update(d)
+        return new
+
+    def __repr__(self):
+        return '{nick} [{id}]'.format(nick=getattr(self, self.NICKNAME), id=getattr(self, self.REG_ID))

--- a/app/model/model.py
+++ b/app/model/model.py
@@ -1133,7 +1133,13 @@ class Model:
                                     'Code in [{0}]'.format(toQuotedStr(itemCodes)))))
         else:
             return []
-     
+
+    def getAttendees(self):
+        return self.__dataset.getAttendees()
+
+    def getAttendee(self, regId):
+        return self.__dataset.getAttendee(regId)
+
     def getItem(self, itemCode):
         if itemCode is None:
             self.__logger.error('getItem: Item code not specified.')

--- a/app/reconciliation/templates/drawersummary.admin.cz.html
+++ b/app/reconciliation/templates/drawersummary.admin.cz.html
@@ -58,7 +58,7 @@
             </tr>
             {% for actorSummary in summary.BuyersToBeCleared %}
             <tr>
-                <td class="colA">{{actorSummary.Badge}}</td>
+                <td class="colA">{{actorSummary.Badge|reg_id_to_attendee}}</td>
                 <td class="colB">{{actorSummary.ItemsToRetrieve}} ks</td>
                 <td class="colC numerical">{{actorSummary.AmountToPay}} Kč</td>
             </tr>
@@ -77,7 +77,7 @@
             </tr>
             {% for actorSummary in summary.OwnersToBeCreared %}
             <tr>
-                <td class="colA">{{actorSummary.Badge}}</td>
+                <td class="colA">{{actorSummary.Badge|reg_id_to_attendee}}</td>
                 <td class="colB">{{actorSummary.ItemsToFinish}} ks</td>
                 <td class="colC numerical">{{actorSummary.AmountToReceive}} Kč</td>
             </tr>

--- a/app/reconciliation/templates/drawersummary.admin.de.html
+++ b/app/reconciliation/templates/drawersummary.admin.de.html
@@ -58,7 +58,7 @@
             </tr>
             {% for actorSummary in summary.BuyersToBeCleared %}
             <tr>
-                <td class="colA">{{actorSummary.Badge}}</td>
+                <td class="colA">{{actorSummary.Badge|reg_id_to_attendee}}</td>
                 <td class="colB">{{actorSummary.ItemsToRetrieve}} pcs.</td>
                 <td class="colC numerical">{{actorSummary.AmountToPay}} €</td>
             </tr>
@@ -77,7 +77,7 @@
             </tr>
             {% for actorSummary in summary.OwnersToBeCreared %}
             <tr>
-                <td class="colA">{{actorSummary.Badge}}</td>
+                <td class="colA">{{actorSummary.Badge|reg_id_to_attendee}}</td>
                 <td class="colB">{{actorSummary.ItemsToFinish}} pcs.</td>
                 <td class="colC numerical">{{actorSummary.AmountToReceive}} €</td>
             </tr>

--- a/app/reconciliation/templates/drawersummary.admin.en.html
+++ b/app/reconciliation/templates/drawersummary.admin.en.html
@@ -58,7 +58,7 @@
             </tr>
             {% for actorSummary in summary.BuyersToBeCleared %}
             <tr>
-                <td class="colA">{{actorSummary.Badge}}</td>
+                <td class="colA">{{actorSummary.Badge|reg_id_to_attendee}}</td>
                 <td class="colB">{{actorSummary.ItemsToRetrieve}} pcs.</td>
                 <td class="colC numerical">{{actorSummary.AmountToPay}} €</td>
             </tr>
@@ -77,7 +77,7 @@
             </tr>
             {% for actorSummary in summary.OwnersToBeCreared %}
             <tr>
-                <td class="colA">{{actorSummary.Badge}}</td>
+                <td class="colA">{{actorSummary.Badge|reg_id_to_attendee}}</td>
                 <td class="colB">{{actorSummary.ItemsToFinish}} pcs.</td>
                 <td class="colC numerical">{{actorSummary.AmountToReceive}} €</td>
             </tr>

--- a/app/reconciliation/templates/findbadgetoreconciliate.admin.cz.html
+++ b/app/reconciliation/templates/findbadgetoreconciliate.admin.cz.html
@@ -11,10 +11,14 @@
     <fieldset>
         <div class="subblock">
             <label for="badge">Číslo visačky:</label>
-            <input id="badge" name="Badge" type="number" value="" required
-                autocomplete="off" autofocus
-                min="1" pattern="[1-9][0-9]*"
+            <input id="badge" name="Badge" required
+                autocomplete="off" autofocus list="attendees"
                 title="Visačka účastníka."/>
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </div>
         <div class="subblock">
             <input class="action" type="submit" formaction="{{findTarget}}" formmethod="post"

--- a/app/reconciliation/templates/findbadgetoreconciliate.admin.de.html
+++ b/app/reconciliation/templates/findbadgetoreconciliate.admin.de.html
@@ -11,10 +11,14 @@
     <fieldset>
         <div class="subblock">
             <label for="badge">Badge number:</label>
-            <input id="badge" name="Badge" type="number" value="" required
-                autocomplete="off" autofocus
-                min="1" pattern="[1-9][0-9]*"
+            <input id="badge" name="Badge" required
+                autocomplete="off" autofocus list="attendees"
                 title="Badge number."/>
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </div>
         <div class="subblock">
             <input class="action" type="submit" formaction="{{findTarget}}" formmethod="post"

--- a/app/reconciliation/templates/findbadgetoreconciliate.admin.en.html
+++ b/app/reconciliation/templates/findbadgetoreconciliate.admin.en.html
@@ -11,10 +11,14 @@
     <fieldset>
         <div class="subblock">
             <label for="badge">Badge number:</label>
-            <input id="badge" name="Badge" type="number" value="" required
+            <input id="badge" name="Badge" value="" required list="attendees"
                 autocomplete="off" autofocus
-                min="1" pattern="[1-9][0-9]*"
                 title="Badge number."/>
+            <datalist id="attendees">
+                {% for attendee in attendees %}
+                    <option value="{{ attendee.RegId }}" label="{{ attendee }}"/>
+                {% endfor %}
+            </datalist>
         </div>
         <div class="subblock">
             <input class="action" type="submit" formaction="{{findTarget}}" formmethod="post"

--- a/app/reconciliation/templates/receipt.admin.cz.html
+++ b/app/reconciliation/templates/receipt.admin.cz.html
@@ -43,7 +43,7 @@
                 </tr>
                 <tr>
                     <td class="colA">Visačka:</td>
-                    <td class="colC">{{badge|default('?')}}</td>
+                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
                 </tr>
             </table>
         </div>
@@ -100,7 +100,7 @@
                 </tr>
                 <tr>
                     <td class="colA">Visačka:</td>
-                    <td class="colC">{{badge|default('?')}}</td>
+                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
                 </tr>
             </table>
         </div>

--- a/app/reconciliation/templates/receipt.admin.de.html
+++ b/app/reconciliation/templates/receipt.admin.de.html
@@ -43,7 +43,7 @@
                 </tr>
                 <tr>
                     <td class="colA">Badgenummer:</td>
-                    <td class="colC">{{badge|default('?')}}</td>
+                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
                 </tr>
             </table>
         </div>
@@ -95,7 +95,7 @@
                 </tr>
                 <tr>
                     <td class="colA">Badgenummer:</td>
-                    <td class="colC">{{badge|default('?')}}</td>
+                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
                 </tr>
             </table>
         </div>

--- a/app/reconciliation/templates/receipt.admin.en.html
+++ b/app/reconciliation/templates/receipt.admin.en.html
@@ -43,7 +43,7 @@
                 </tr>
                 <tr>
                     <td class="colA">Badge:</td>
-                    <td class="colC">{{badge|default('?')}}</td>
+                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
                 </tr>
             </table>
         </div>
@@ -95,7 +95,7 @@
                 </tr>
                 <tr>
                     <td class="colA">Badge:</td>
-                    <td class="colC">{{badge|default('?')}}</td>
+                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
                 </tr>
             </table>
         </div>

--- a/app/reconciliation/templates/reconciliation.admin.cz.html
+++ b/app/reconciliation/templates/reconciliation.admin.cz.html
@@ -6,7 +6,7 @@
     <title>ArtShow: Přehled vypořádání</title>
 </head>
 <body>
-    <h1>Přehled vypořádání visačky {{badge|default('?')}}</h1>
+    <h1>Přehled vypořádání visačky {{badge|reg_id_to_attendee}}</h1>
     <div class="infoBlock">
         {% if summary.TotalDueAmount >= 0 %}
         <p><span>Přijmi:</span> {{summary.TotalDueAmount|default(0)}} Kč</p>

--- a/app/reconciliation/templates/reconciliation.admin.de.html
+++ b/app/reconciliation/templates/reconciliation.admin.de.html
@@ -6,7 +6,7 @@
     <title>ArtShow: Reconciliation</title>
 </head>
 <body>
-    <h1>Reconcile a Badge {{badge|default('?')}}</h1>
+    <h1>Reconcile a Badge {{badge|reg_id_to_attendee}}</h1>
     <div class="infoBlock">
         {% if summary.TotalDueAmount >= 0 %}
         <p><span>Get:</span> {{summary.TotalDueAmount|default(0)}} €</p>

--- a/app/reconciliation/templates/reconciliation.admin.en.html
+++ b/app/reconciliation/templates/reconciliation.admin.en.html
@@ -6,7 +6,7 @@
     <title>ArtShow: Reconciliation</title>
 </head>
 <body>
-    <h1>Reconcile a Badge {{badge|default('?')}}</h1>
+    <h1>Reconcile {{badge|reg_id_to_attendee}}</h1>
     <div class="infoBlock">
         {% if summary.TotalDueAmount >= 0 %}
         <p><span>Get:</span> {{summary.TotalDueAmount|default(0)}} €</p>

--- a/app/reconciliation/templates/runneroverview.admin.cz.html
+++ b/app/reconciliation/templates/runneroverview.admin.cz.html
@@ -20,7 +20,7 @@
         <input class="hidden" name="SummaryChecksum" type="number"
                value="{{summaryChecksum}}" />
     </form>
-    <h1>Visačka: {{badge|default('?')}}</h1>
+    <h1>Visačka: {{badge|reg_id_to_attendee}}</h1>
     <div class="listSection receiptSection col3">
         <table>
             <tr>

--- a/app/reconciliation/templates/runneroverview.admin.de.html
+++ b/app/reconciliation/templates/runneroverview.admin.de.html
@@ -20,7 +20,7 @@
         <input class="hidden" name="SummaryChecksum" type="number"
                value="{{summaryChecksum}}" />
     </form>
-    <h1>Badge: {{badge|default('?')}}</h1>
+    <h1>Badge: {{badge|reg_id_to_attendee}}</h1>
     <div class="listSection receiptSection col3">
         <table>
             <tr>

--- a/app/reconciliation/templates/runneroverview.admin.en.html
+++ b/app/reconciliation/templates/runneroverview.admin.en.html
@@ -20,7 +20,7 @@
         <input class="hidden" name="SummaryChecksum" type="number"
                value="{{summaryChecksum}}" />
     </form>
-    <h1>Badge: {{badge|default('?')}}</h1>
+    <h1>Badge: {{badge|reg_id_to_attendee}}</h1>
     <div class="listSection receiptSection col3">
         <table>
             <tr>


### PR DESCRIPTION
This adds another XML-table to the application which consists as a static list of attendees.

Each appearence of attendees as item owner or buyer has been replaced/enriched for displaying purposes with `<nickname> [<regid>]` or for input fields, HTML5's "list" attribute is used like it already is in other parts of the application.

A downside of this is that browsers currently show the "value" which is still just the registration ID in the input field instead of the "label". But when searching the field (that is, when clicking on it and/or typing in it), an automatically filtered (by current input) list of attendee names is shown.

IMO, as a first step, using this browser feature (tested with Firefox and Chrome) without additional Javascript requirements is a very good trade off. Let's see if someone complains about the input fields only containing numbers and we can change it still later on.

Here are some screens. I actually wanted to make a screencast, but the VirtualBox I'm using for developing doesn't allow. It even crashes when just pressing the "print" key <.<

![cesfur_83_screen_item_list](https://cloud.githubusercontent.com/assets/1580789/24330685/8a22a016-1224-11e7-8abe-73bbf5b7b8f3.png)
![cesfur_83_screen_item_selected](https://cloud.githubusercontent.com/assets/1580789/24330683/8a21d42e-1224-11e7-8d46-15383aa16df7.png)
![cesfur_83_screen_item_typing_1](https://cloud.githubusercontent.com/assets/1580789/24330687/8a264e5a-1224-11e7-8e64-106400c1d839.png)
![cesfur_83_screen_item_typing_2](https://cloud.githubusercontent.com/assets/1580789/24330686/8a24da20-1224-11e7-8434-5f030b2318fe.png)
![cesfur_83_screen_reconcile_header](https://cloud.githubusercontent.com/assets/1580789/24330684/8a225ca0-1224-11e7-9fd7-86fe26cd5938.png)
