### PR TITLE
Change artshow recipie

### DIFF
--- a/app/common/texttable.py
+++ b/app/common/texttable.py
@@ -1,0 +1,645 @@
+# texttable - module for creating simple ASCII tables
+# Copyright (C) 2003-2015 Gerome Fournier <jef(at)foutaise.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+"""module for creating simple ASCII tables
+
+
+Example:
+
+    table = Texttable()
+    table.set_cols_align(["l", "r", "c"])
+    table.set_cols_valign(["t", "m", "b"])
+    table.add_rows([["Name", "Age", "Nickname"],
+                    ["Mr\\nXavier\\nHuon", 32, "Xav'"],
+                    ["Mr\\nBaptiste\\nClement", 1, "Baby"],
+                    ["Mme\\nLouise\\nBourgeau", 28, "Lou\\n\\nLoue"]])
+    print table.draw() + "\\n"
+
+    table = Texttable()
+    table.set_deco(Texttable.HEADER)
+    table.set_cols_dtype(['t',  # text
+                          'f',  # float (decimal)
+                          'e',  # float (exponent)
+                          'i',  # integer
+                          'a']) # automatic
+    table.set_cols_align(["l", "r", "r", "r", "l"])
+    table.add_rows([["text",    "float", "exp", "int", "auto"],
+                    ["abcd",    "67",    654,   89,    128.001],
+                    ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
+                    ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
+                    ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000]])
+    print table.draw()
+
+Result:
+
+    +----------+-----+----------+
+    |   Name   | Age | Nickname |
+    +==========+=====+==========+
+    | Mr       |     |          |
+    | Xavier   |  32 |          |
+    | Huon     |     |   Xav'   |
+    +----------+-----+----------+
+    | Mr       |     |          |
+    | Baptiste |   1 |          |
+    | Clement  |     |   Baby   |
+    +----------+-----+----------+
+    | Mme      |     |   Lou    |
+    | Louise   |  28 |          |
+    | Bourgeau |     |   Loue   |
+    +----------+-----+----------+
+
+    text   float       exp      int     auto
+    ===========================================
+    abcd   67.000   6.540e+02   89    128.001
+    efgh   67.543   6.540e-01   90    1.280e+22
+    ijkl   0.000    5.000e-78   89    0.000
+    mnop   0.023    5.000e+78   92    1.280e+22
+"""
+
+from __future__ import division
+
+__all__ = ["Texttable", "ArraySizeError"]
+
+__author__ = 'Gerome Fournier <jef(at)foutaise.org>'
+__license__ = 'LGPL'
+__version__ = '0.8.8'
+__credits__ = """\
+Jeff Kowalczyk:
+    - textwrap improved import
+    - comment concerning header output
+
+Anonymous:
+    - add_rows method, for adding rows in one go
+
+Sergey Simonenko:
+    - redefined len() function to deal with non-ASCII characters
+
+Roger Lew:
+    - columns datatype specifications
+
+Brian Peterson:
+    - better handling of unicode errors
+
+Frank Sachsenheim:
+    - add Python 2/3-compatibility
+
+Maximilian Hils:
+    - fix minor bug for Python 3 compatibility
+
+frinkelpi:
+    - preserve empty lines
+"""
+
+import sys
+import string
+import unicodedata
+
+try:
+    if sys.version >= '2.3':
+        import textwrap
+    elif sys.version >= '2.2':
+        from optparse import textwrap
+    else:
+        from optik import textwrap
+except ImportError:
+    sys.stderr.write("Can't import textwrap module!\n")
+    raise
+
+if sys.version >= '2.7':
+    from functools import reduce
+
+if sys.version >= '3.0':
+    unicode_type = str
+    bytes_type = bytes
+else:
+    unicode_type = unicode
+    bytes_type = str
+
+
+def obj2unicode(obj):
+    """Return a unicode representation of a python object
+    """
+    if isinstance(obj, unicode_type):
+        return obj
+    elif isinstance(obj, bytes_type):
+        try:
+            return unicode_type(obj, 'utf-8')
+        except UnicodeDecodeError as strerror:
+            sys.stderr.write("UnicodeDecodeError exception for string '%s': %s\n" % (obj, strerror))
+            return unicode_type(obj, 'utf-8', 'replace')
+    else:
+        return unicode_type(obj)
+
+
+def len(iterable):
+    """Redefining len here so it will be able to work with non-ASCII characters
+    """
+    if isinstance(iterable, bytes_type) or isinstance(iterable, unicode_type):
+        unicode_data = obj2unicode(iterable)
+        if hasattr(unicodedata, 'east_asian_width'):
+            w = unicodedata.east_asian_width
+            return sum([w(c) in 'WF' and 2 or 1 for c in unicode_data])
+        else:
+            return unicode_data.__len__()
+    else:
+        return iterable.__len__()
+
+
+class ArraySizeError(Exception):
+    """Exception raised when specified rows don't fit the required size
+    """
+
+    def __init__(self, msg):
+        self.msg = msg
+        Exception.__init__(self, msg, '')
+
+    def __str__(self):
+        return self.msg
+
+
+class Texttable:
+
+    BORDER = 1
+    HEADER = 1 << 1
+    HLINES = 1 << 2
+    VLINES = 1 << 3
+
+    def __init__(self, max_width=80):
+        """Constructor
+
+        - max_width is an integer, specifying the maximum width of the table
+        - if set to 0, size is unlimited, therefore cells won't be wrapped
+        """
+
+        if max_width <= 0:
+            max_width = False
+        self._max_width = max_width
+        self._precision = 3
+
+        self._deco = Texttable.VLINES | Texttable.HLINES | Texttable.BORDER | \
+            Texttable.HEADER
+        self.set_chars(['-', '|', '+', '='])
+        self.reset()
+
+    def reset(self):
+        """Reset the instance
+
+        - reset rows and header
+        """
+
+        self._hline_string = None
+        self._row_size = None
+        self._header = []
+        self._rows = []
+
+    def set_chars(self, array):
+        """Set the characters used to draw lines between rows and columns
+
+        - the array should contain 4 fields:
+
+            [horizontal, vertical, corner, header]
+
+        - default is set to:
+
+            ['-', '|', '+', '=']
+        """
+
+        if len(array) != 4:
+            raise ArraySizeError("array should contain 4 characters")
+        array = [ x[:1] for x in [ str(s) for s in array ] ]
+        (self._char_horiz, self._char_vert,
+            self._char_corner, self._char_header) = array
+
+    def set_deco(self, deco):
+        """Set the table decoration
+
+        - 'deco' can be a combinaison of:
+
+            Texttable.BORDER: Border around the table
+            Texttable.HEADER: Horizontal line below the header
+            Texttable.HLINES: Horizontal lines between rows
+            Texttable.VLINES: Vertical lines between columns
+
+           All of them are enabled by default
+
+        - example:
+
+            Texttable.BORDER | Texttable.HEADER
+        """
+
+        self._deco = deco
+
+    def set_cols_align(self, array):
+        """Set the desired columns alignment
+
+        - the elements of the array should be either "l", "c" or "r":
+
+            * "l": column flushed left
+            * "c": column centered
+            * "r": column flushed right
+        """
+
+        self._check_row_size(array)
+        self._align = array
+
+    def set_cols_valign(self, array):
+        """Set the desired columns vertical alignment
+
+        - the elements of the array should be either "t", "m" or "b":
+
+            * "t": column aligned on the top of the cell
+            * "m": column aligned on the middle of the cell
+            * "b": column aligned on the bottom of the cell
+        """
+
+        self._check_row_size(array)
+        self._valign = array
+
+    def set_cols_dtype(self, array):
+        """Set the desired columns datatype for the cols.
+
+        - the elements of the array should be either "a", "t", "f", "e" or "i":
+
+            * "a": automatic (try to use the most appropriate datatype)
+            * "t": treat as text
+            * "f": treat as float in decimal format
+            * "e": treat as float in exponential format
+            * "i": treat as int
+
+        - by default, automatic datatyping is used for each column
+        """
+
+        self._check_row_size(array)
+        self._dtype = array
+
+    def set_cols_width(self, array):
+        """Set the desired columns width
+
+        - the elements of the array should be integers, specifying the
+          width of each column. For example:
+
+                [10, 20, 5]
+        """
+
+        self._check_row_size(array)
+        try:
+            array = list(map(int, array))
+            if reduce(min, array) <= 0:
+                raise ValueError
+        except ValueError:
+            sys.stderr.write("Wrong argument in column width specification\n")
+            raise
+        self._width = array
+
+    def set_precision(self, width):
+        """Set the desired precision for float/exponential formats
+
+        - width must be an integer >= 0
+
+        - default value is set to 3
+        """
+
+        if not type(width) is int or width < 0:
+            raise ValueError('width must be an integer greater then 0')
+        self._precision = width
+
+    def header(self, array):
+        """Specify the header of the table
+        """
+
+        self._check_row_size(array)
+        self._header = list(map(obj2unicode, array))
+
+    def add_row(self, array):
+        """Add a row in the rows stack
+
+        - cells can contain newlines and tabs
+        """
+
+        self._check_row_size(array)
+
+        if not hasattr(self, "_dtype"):
+            self._dtype = ["a"] * self._row_size
+
+        cells = []
+        for i, x in enumerate(array):
+            cells.append(self._str(i, x))
+        self._rows.append(cells)
+
+    def add_rows(self, rows, header=True):
+        """Add several rows in the rows stack
+
+        - The 'rows' argument can be either an iterator returning arrays,
+          or a by-dimensional array
+        - 'header' specifies if the first row should be used as the header
+          of the table
+        """
+
+        # nb: don't use 'iter' on by-dimensional arrays, to get a
+        #     usable code for python 2.1
+        if header:
+            if hasattr(rows, '__iter__') and hasattr(rows, 'next'):
+                self.header(rows.next())
+            else:
+                self.header(rows[0])
+                rows = rows[1:]
+        for row in rows:
+            self.add_row(row)
+
+    def draw(self):
+        """Draw the table
+
+        - the table is returned as a whole string
+        """
+
+        if not self._header and not self._rows:
+            return
+        self._compute_cols_width()
+        self._check_align()
+        out = ""
+        if self._has_border():
+            out += self._hline()
+        if self._header:
+            out += self._draw_line(self._header, isheader=True)
+            if self._has_header():
+                out += self._hline_header()
+        length = 0
+        for row in self._rows:
+            length += 1
+            out += self._draw_line(row)
+            if self._has_hlines() and length < len(self._rows):
+                out += self._hline()
+        if self._has_border():
+            out += self._hline()
+        return out[:-1]
+
+    def _str(self, i, x):
+        """Handles string formatting of cell data
+
+            i - index of the cell datatype in self._dtype
+            x - cell data to format
+        """
+        try:
+            f = float(x)
+        except:
+            return obj2unicode(x)
+
+        n = self._precision
+        dtype = self._dtype[i]
+
+        if dtype == 'i':
+            return str(int(round(f)))
+        elif dtype == 'f':
+            return '%.*f' % (n, f)
+        elif dtype == 'e':
+            return '%.*e' % (n, f)
+        elif dtype == 't':
+            return obj2unicode(x)
+        else:
+            if f - round(f) == 0:
+                if abs(f) > 1e8:
+                    return '%.*e' % (n, f)
+                else:
+                    return str(int(round(f)))
+            else:
+                if abs(f) > 1e8:
+                    return '%.*e' % (n, f)
+                else:
+                    return '%.*f' % (n, f)
+
+    def _check_row_size(self, array):
+        """Check that the specified array fits the previous rows size
+        """
+
+        if not self._row_size:
+            self._row_size = len(array)
+        elif self._row_size != len(array):
+            raise ArraySizeError("array should contain %d elements" \
+                % self._row_size)
+
+    def _has_vlines(self):
+        """Return a boolean, if vlines are required or not
+        """
+
+        return self._deco & Texttable.VLINES > 0
+
+    def _has_hlines(self):
+        """Return a boolean, if hlines are required or not
+        """
+
+        return self._deco & Texttable.HLINES > 0
+
+    def _has_border(self):
+        """Return a boolean, if border is required or not
+        """
+
+        return self._deco & Texttable.BORDER > 0
+
+    def _has_header(self):
+        """Return a boolean, if header line is required or not
+        """
+
+        return self._deco & Texttable.HEADER > 0
+
+    def _hline_header(self):
+        """Print header's horizontal line
+        """
+
+        return self._build_hline(True)
+
+    def _hline(self):
+        """Print an horizontal line
+        """
+
+        if not self._hline_string:
+            self._hline_string = self._build_hline()
+        return self._hline_string
+
+    def _build_hline(self, is_header=False):
+        """Return a string used to separated rows or separate header from
+        rows
+        """
+        horiz = self._char_horiz
+        if (is_header):
+            horiz = self._char_header
+        # compute cell separator
+        s = "%s%s%s" % (horiz, [horiz, self._char_corner][self._has_vlines()],
+            horiz)
+        # build the line
+        l = s.join([horiz * n for n in self._width])
+        # add border if needed
+        if self._has_border():
+            l = "%s%s%s%s%s\n" % (self._char_corner, horiz, l, horiz,
+                self._char_corner)
+        else:
+            l += "\n"
+        return l
+
+    def _len_cell(self, cell):
+        """Return the width of the cell
+
+        Special characters are taken into account to return the width of the
+        cell, such like newlines and tabs
+        """
+
+        cell_lines = cell.split('\n')
+        maxi = 0
+        for line in cell_lines:
+            length = 0
+            parts = line.split('\t')
+            for part, i in zip(parts, list(range(1, len(parts) + 1))):
+                length = length + len(part)
+                if i < len(parts):
+                    length = (length//8 + 1) * 8
+            maxi = max(maxi, length)
+        return maxi
+
+    def _compute_cols_width(self):
+        """Return an array with the width of each column
+
+        If a specific width has been specified, exit. If the total of the
+        columns width exceed the table desired width, another width will be
+        computed to fit, and cells will be wrapped.
+        """
+
+        if hasattr(self, "_width"):
+            return
+        maxi = []
+        if self._header:
+            maxi = [ self._len_cell(x) for x in self._header ]
+        for row in self._rows:
+            for cell,i in zip(row, list(range(len(row)))):
+                try:
+                    maxi[i] = max(maxi[i], self._len_cell(cell))
+                except (TypeError, IndexError):
+                    maxi.append(self._len_cell(cell))
+
+        ncols = len(maxi)
+        content_width = sum(maxi)
+        deco_width = 3*(ncols-1) + [0,4][self._has_border()]
+        if self._max_width and (content_width + deco_width) > self._max_width:
+            """ content too wide to fit the expected max_width
+            let's recompute maximum cell width for each cell
+            """
+            if self._max_width < (ncols + deco_width):
+                raise ValueError('max_width too low to render data')
+            available_width = self._max_width - deco_width
+            newmaxi = [0] * ncols
+            i = 0
+            while available_width > 0:
+                if newmaxi[i] < maxi[i]:
+                    newmaxi[i] += 1
+                    available_width -= 1
+                i = (i + 1) % ncols
+            maxi = newmaxi
+        self._width = maxi
+
+    def _check_align(self):
+        """Check if alignment has been specified, set default one if not
+        """
+
+        if not hasattr(self, "_align"):
+            self._align = ["l"] * self._row_size
+        if not hasattr(self, "_valign"):
+            self._valign = ["t"] * self._row_size
+
+    def _draw_line(self, line, isheader=False):
+        """Draw a line
+
+        Loop over a single cell length, over all the cells
+        """
+
+        line = self._splitit(line, isheader)
+        space = " "
+        out = ""
+        for i in range(len(line[0])):
+            if self._has_border():
+                out += "%s " % self._char_vert
+            length = 0
+            for cell, width, align in zip(line, self._width, self._align):
+                length += 1
+                cell_line = cell[i]
+                fill = width - len(cell_line)
+                if isheader:
+                    align = "c"
+                if align == "r":
+                    out += fill * space + cell_line
+                elif align == "c":
+                    out += (int(fill/2) * space + cell_line \
+                            + int(fill/2 + fill%2) * space)
+                else:
+                    out += cell_line + fill * space
+                if length < len(line):
+                    out += " %s " % [space, self._char_vert][self._has_vlines()]
+            out += "%s\n" % ['', space + self._char_vert][self._has_border()]
+        return out
+
+    def _splitit(self, line, isheader):
+        """Split each element of line to fit the column width
+
+        Each element is turned into a list, result of the wrapping of the
+        string to the desired width
+        """
+
+        line_wrapped = []
+        for cell, width in zip(line, self._width):
+            array = []
+            for c in cell.split('\n'):
+                if c.strip() == "":
+                    array.append("")
+                else:
+                    array.extend(textwrap.wrap(c, width))
+            line_wrapped.append(array)
+        max_cell_lines = reduce(max, list(map(len, line_wrapped)))
+        for cell, valign in zip(line_wrapped, self._valign):
+            if isheader:
+                valign = "t"
+            if valign == "m":
+                missing = max_cell_lines - len(cell)
+                cell[:0] = [""] * int(missing / 2)
+                cell.extend([""] * int(missing / 2 + missing % 2))
+            elif valign == "b":
+                cell[:0] = [""] * (max_cell_lines - len(cell))
+            else:
+                cell.extend([""] * (max_cell_lines - len(cell)))
+        return line_wrapped
+
+
+if __name__ == '__main__':
+    table = Texttable()
+    table.set_cols_align(["l", "r", "c"])
+    table.set_cols_valign(["t", "m", "b"])
+    table.add_rows([["Name", "Age", "Nickname"],
+                    ["Mr\nXavier\nHuon", 32, "Xav'"],
+                    ["Mr\nBaptiste\nClement", 1, "Baby"],
+                    ["Mme\nLouise\nBourgeau", 28, "Lou\n \nLoue"]])
+    print(table.draw() + "\n")
+
+    table = Texttable()
+    table.set_deco(Texttable.HEADER)
+    table.set_cols_dtype(['t',  # text
+                          'f',  # float (decimal)
+                          'e',  # float (exponent)
+                          'i',  # integer
+                          'a']) # automatic
+    table.set_cols_align(["l", "r", "r", "r", "l"])
+    table.add_rows([["text",    "float", "exp", "int", "auto"],
+                    ["abcd",    "67",    654,   89,    128.001],
+                    ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
+                    ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
+                    ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000]])
+    print(table.draw())

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
+import textwrap
 from argparse import ArgumentParser
 
 import flask
@@ -38,7 +39,7 @@ from model.model import Model
 
 from items import items_controller
 from auction import auction_controller
-from reconciliation import reconciliation_controller
+from reconciliation import reconciliation_controller, filters
 from settings import settings_controller
 
 # Configure logging
@@ -81,6 +82,19 @@ del dictionaryPath
 def reg_id_to_attendee(s):
     """ For a given reg ID, return Attendee instance """
     return flask.g.model.getAttendee(s)
+
+
+@app.template_filter('textwrap')
+def _textwrap(value, cols):
+    """ Wrap text using the given number of columns """
+    return textwrap.fill(value, cols)
+
+
+@app.template_filter('dateformat')
+def datetimeformat(value, format_str):
+    """ Format datetime using Python3 format string (*not* strftime!)"""
+    format_str = '{:' + format_str + '}'
+    return format_str.format(value)
 
 
 @app.context_processor

--- a/app/reconciliation/filters.py
+++ b/app/reconciliation/filters.py
@@ -1,0 +1,72 @@
+import flask
+
+from common.texttable import Texttable
+from .reconciliation_controller import blueprint
+
+
+# adds up to 36 - four columns are used as column separators
+ID_WIDTH = 4
+TEXT_WIDTH = 27
+PRICE_WIDTH = 5
+HLINE = ['-' * ID_WIDTH, '-' * TEXT_WIDTH, '-' * PRICE_WIDTH]
+
+
+def _tbl(rows):
+    t = Texttable()
+    # we want to make our tables always look the same, so set static width
+    t.set_cols_width([ID_WIDTH, TEXT_WIDTH, PRICE_WIDTH])
+    # Texttable adds 1 space of padding left and right of all cells, plus one
+    # character for vertical lines, even if VLINES is not set. In order to make
+    # it not print just another space (adding up to three), replace VLINES char
+    # by empty string
+    t.set_deco(Texttable.VLINES)
+    t.set_chars(['-', '', '+', '='])
+    t.set_cols_align(['l', 'l', 'r'])
+    # header gets printed differently, so skip
+    t.add_rows(rows, header=False)
+    return t.draw()
+
+
+@blueprint.app_template_filter('unsold_table')
+def unsold_table(items):
+    """ format """
+    return _tbl([[
+        '#{}'.format(item['Code']),
+        '{}'.format(item['Title']),
+        '',
+    ] for item in items])
+
+
+@blueprint.app_template_filter('sold_table')
+def sold_table(items, total, charity):
+    return _tbl([[
+        '#{}'.format(item['Code']),
+        '{}\nBuyer: {}'.format(item['Title'], flask.g.model.getAttendee(item['Buyer'])),
+        '{}€'.format(item['Amount']),
+    ] for item in items] + [
+        HLINE,
+        ['', 'Total income', '{}€'.format(total)],
+        ['', 'Charity contrib.', '{}€'.format(charity)],
+        ['', 'Remaining', '{}€'.format(total - charity)],
+    ])
+
+
+@blueprint.app_template_filter('bought_table')
+def bought_table(items, total):
+    return _tbl([[
+        '#{}'.format(item['Code']),
+        '{}\nSeller: {}'.format(item['Title'], flask.g.model.getAttendee(item['Owner'])),
+        '{}€'.format(item['Amount']),
+    ] for item in items] + [
+        HLINE,
+        ['', 'Total', '{}€'.format(total)],
+    ])
+
+
+@blueprint.app_template_filter('cash_table')
+def cash_table(total):
+    rows = [
+        ['', 'Collected', '{}€'.format(max(total, 0))],
+        ['', 'Handed Over', '{}€'.format(min(total, 0))],
+    ]
+    return _tbl(rows)

--- a/app/reconciliation/templates/receipt.admin.cz.html
+++ b/app/reconciliation/templates/receipt.admin.cz.html
@@ -25,166 +25,45 @@
         </fieldset>
     </form>
 
-    <div class="notShown">
+    <div class="artshowOverview notShown">
+        <pre>
+Artshow Overview
+{{datetime|dateformat("%B %d, %Y, %H:%M")}}
+Attendee: {{badge|reg_id_to_attendee}}
 
-        <!-- Artshow Copy -->
-        <h1>Vypořádání</h1>
-        <p>Kopie pro Artshow</p>
-        <div class="receiptSection col2">
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Datum:</td>
-                    <td class="colC">{{datetime.day}}. {{datetime.month}}. {{datetime.year}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Čas:</td>
-                    <td class="colC">{{"%d:%02d"|format(datetime.hour, datetime.minute)}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Visačka:</td>
-                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
-                </tr>
-            </table>
-        </div>
-        <div class="receiptSection col2">
-            <h2>Shrnutí</h2>
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Prodáno za:</td>
-                    <td class="colC">{{summary.GrossSaleAmount|default('?')}} Kč</td>
-                </tr>
-                <tr>
-                    <td class="colA">Na charitu:</td>
-                    <td class="colC">{{summary.CharityDeduction|default('?')}} Kč</td>
-                </tr>
-                <tr>
-                    <td class="colA">Zakoupeno za:</td>
-                    <td class="colC">{{summary.BoughtItemsAmount|default('?')}} Kč</td>
-                </tr>
-                {% if summary.TotalDueAmount >= 0 %}
-                <tr>
-                    <td class="colA">Uhrazeno:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0)}} Kč</td>
-                </tr>
-                {% else %}
-                <tr>
-                    <td class="colA">Vyplaceno:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0) * -1}} Kč</td>
-                </tr>
-                {% endif %}
-            </table>
-        </div>
-        {% if summary.TotalDueAmount >= 0 %}
-        <p>Podpisem stvrzuji, že nemám vůči výstavě na akci ČeSFur žádné závazky a že jsem převzal předměty mě náležející.</p>
-        {% else %}
-        <p>Podpisem stvrzuji, že nemám vůči výstavě na akci ČeSFur žádné závazky a že jsem převzal předměty mě náležející a přijal výše uvedenou částku.</p>
-        {% endif %}
-        <p>V Praze, {{datetime.day}}. {{datetime.month}}. {{datetime.year}}</p>
-        <div class="signature"></div>
-        <div class="pageBreak"></div>
+{% if summary.AvailUnsoldItems -%}
+Unsold items which were returned:
+{{ summary.AvailUnsoldItems|unsold_table }}
 
-        <!-- Customer Copy -->
-        <h1>Vypořádání</h1>
-        <div class="receiptSection col2">
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Datum:</td>
-                    <td class="colC">{{datetime.day}}. {{datetime.month}}. {{datetime.year}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Čas:</td>
-                    <td class="colC">{{"%d:%02d"|format(datetime.hour, datetime.minute)}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Visačka:</td>
-                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
-                </tr>
-            </table>
-        </div>
-        <div class="receiptSection col2">
-            <h2>Shrnutí</h2>
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Prodáno za:</td>
-                    <td class="colC">{{summary.GrossSaleAmount|default('?')}} Kč</td>
-                </tr>
-                <tr>
-                    <td class="colA">Na charitu:</td>
-                    <td class="colC">{{summary.CharityDeduction|default('?')}} Kč</td>
-                </tr>
-                <tr>
-                    <td class="colA">Zakoupeno za:</td>
-                    <td class="colC">{{summary.BoughtItemsAmount|default('?')}} Kč</td>
-                </tr>
-                {% if summary.TotalDueAmount >= 0 %}
-                <tr>
-                    <td class="colA">Uhrazeno:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0)}} Kč</td>
-                </tr>
-                {% else %}
-                <tr>
-                    <td class="colA">Vyplaceno:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0) * -1}} Kč</td>
-                </tr>
-                {% endif %}
-            </table>
-        </div>
-        {% if summary.AvailBoughtItems|length > 0 %}
-        <div class="receiptSection col2">
-            <h2>Zakoupené</h2>
-            <table>
-                <tr>
-                    <th class="colA">Název</th>
-                    <th class="colC">Zaplaceno</th>
-                </tr>
-                {% for item in summary.AvailBoughtItems %}
-                <tr>
-                    <td class="colA">{{item.Title}}</td>
-                    <td class="colC">{{item.Amount}} Kč</td>
-                </tr>
-                {% endfor %}
-            </table>
-        </div>
-        {% endif %}
+{% endif -%}
+{% if summary.DeliveredSoldItems -%}
+Sold items:
+{{ summary.DeliveredSoldItems|sold_table(summary.GrossSaleAmount, summary.CharityDeduction) }}
 
-        {% if summary.AvailUnsoldItems|length > 0 %}
-        <div class="receiptSection col1">
-            <h2>Neprodané</h2>
-            <table>
-                <tr>
-                    <th class="colA">Název</th>
-                </tr>
-                {% for item in summary.AvailUnsoldItems %}
-                <tr>
-                    <td class="colA">{{item.Title}}</td>
-                </tr>
-                {% endfor %}
-            </table>
-        </div>
-        {% endif %}
+{{ 'Charity contribution is given by the seller after paying out the income to the seller.'|textwrap(40) }}
 
-        {% if summary.DeliveredSoldItems|length > 0 %}
-        <div class="receiptSection col2">
-            <h2>Proplacené</h2>
-            <table>
-                <tr>
-                    <th class="colA">Název</th>
-                    <th class="colC">Proplaceno</th>
-                </tr>
-                {% for item in summary.DeliveredSoldItems %}
-                <tr>
-                    <td class="colA">{{item.Title}}</td>
-                    <td class="colC">{{item.NetAmount}} Kč</td>
-                </tr>
-                {% endfor %}
-            </table>
-        </div>
-        {% endif %}
+{% endif -%}
+{% if summary.AvailBoughtItems -%}
+Bought items:
+{{ summary.AvailBoughtItems|bought_table(summary.BoughtItemsAmount) }}
 
+{% endif -%}
+
+Cash:
+{{ summary.TotalDueAmount|cash_table }}
+
+{{ 'By selling and/or buying items in Artshow, buyers and sellers acknowledge that CeSFuR z.s. does not own, sell, or buy any of the items in the Artshow unless written explicitly. Sale agreement is always formed between the seller and the buyer.'|textwrap(40) }}
+
+{% if summary.DeliveredSoldItems -%}
+{{ 'By selling items I agree that CeSFuR z.s. will collect cash from buyers without any commission.'|textwrap(40) }}
+
+{% endif -%}
+{% if summary.AvailBoughtItems -%}
+{{ 'By accepting bought items I agree that CeSFuR z.s. will hand over cash to the seller without any commission. I agree to contact seller directly if further details about the sale is required.'|textwrap(40) }}
+
+{% endif -%}
+This document is not a legal invoice.
+</pre>
     </div>
 </body>
 </html>

--- a/app/reconciliation/templates/receipt.admin.en.html
+++ b/app/reconciliation/templates/receipt.admin.en.html
@@ -25,161 +25,45 @@
         </fieldset>
     </form>
 
-    <div class="notShown">
+    <div class="artshowOverview notShown">
+        <pre>
+Artshow Overview
+{{datetime|dateformat("%B %d, %Y, %H:%M")}}
+Attendee: {{badge|reg_id_to_attendee}}
 
-        <!-- Artshow Copy -->
-        <h1>Reconciliation</h1>
-        <p>Artshow Copy</p>
-        <div class="receiptSection col2">
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Date:</td>
-                    <td class="colC">{{datetime.month}}/{{datetime.day}}/{{datetime.year}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Time:</td>
-                    <td class="colC">{{"%d:%02d"|format(datetime.hour, datetime.minute)}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Badge:</td>
-                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
-                </tr>
-            </table>
-        </div>
-        <div class="receiptSection col2">
-            <h2>Summary</h2>
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Sold For:</td>
-                    <td class="colC">{{summary.GrossSaleAmount|default('?')}}€</td>
-                </tr>
-                <tr>
-                    <td class="colA">Charity Ded.:</td>
-                    <td class="colC">{{summary.CharityDeduction|default('?')}}€</td>
-                </tr>
-                <tr>
-                    <td class="colA">Bought For:</td>
-                    <td class="colC">{{summary.BoughtItemsAmount|default('?')}}€</td>
-                </tr>
-                {% if summary.TotalDueAmount >= 0 %}
-                <tr>
-                    <td class="colA">Paid:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0)}}€</td>
-                </tr>
-                {% else %}
-                <tr>
-                    <td class="colA">Received:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0) * -1}}€</td>
-                </tr>
-                {% endif %}
-            </table>
-        </div>
-        <p>In Dessau, {{datetime.month}}/{{datetime.day}}/{{datetime.year}}</p>
-        <div class="signature"></div>
-        <div class="pageBreak"></div>
+{% if summary.AvailUnsoldItems -%}
+Unsold items which were returned:
+{{ summary.AvailUnsoldItems|unsold_table }}
 
-        <!-- Badge Copy -->
-        <h1>Reconciliation</h1>
-        <div class="receiptSection col2">
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Date:</td>
-                    <td class="colC">{{datetime.month}}/{{datetime.day}}/{{datetime.year}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Time:</td>
-                    <td class="colC">{{"%d:%02d"|format(datetime.hour, datetime.minute)}}</td>
-                </tr>
-                <tr>
-                    <td class="colA">Badge:</td>
-                    <td class="colC">{{badge|reg_id_to_attendee}}</td>
-                </tr>
-            </table>
-        </div>
-        <div class="receiptSection col2">
-            <h2>Summary</h2>
-            <table>
-                <tr class="hidden"><th>A</th><th>C</th></tr>
-                <tr>
-                    <td class="colA">Sold For:</td>
-                    <td class="colC">{{summary.GrossSaleAmount|default('?')}}€</td>
-                </tr>
-                <tr>
-                    <td class="colA">Charity Ded.:</td>
-                    <td class="colC">{{summary.CharityDeduction|default('?')}}€</td>
-                </tr>
-                <tr>
-                    <td class="colA">Bought For:</td>
-                    <td class="colC">{{summary.BoughtItemsAmount|default('?')}}€</td>
-                </tr>
-                {% if summary.TotalDueAmount >= 0 %}
-                <tr>
-                    <td class="colA">Paid:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0)}}€</td>
-                </tr>
-                {% else %}
-                <tr>
-                    <td class="colA">Received:</td>
-                    <td class="colC">{{summary.TotalDueAmount|default(0) * -1}}€</td>
-                </tr>
-                {% endif %}
-            </table>
-        </div>
-        {% if summary.AvailBoughtItems|length > 0 %}
-        <div class="receiptSection col2">
-            <h2>Bought Items</h2>
-            <table>
-                <tr>
-                    <th class="colA">Title</th>
-                    <th class="colC">Amount</th>
-                </tr>
-                {% for item in summary.AvailBoughtItems %}
-                <tr>
-                    <td class="colA">{{item.Title}}</td>
-                    <td class="colC">{{item.Amount}}€</td>
-                </tr>
-                {% endfor %}
-            </table>
-        </div>
-        {% endif %}
+{% endif -%}
+{% if summary.DeliveredSoldItems -%}
+Sold items:
+{{ summary.DeliveredSoldItems|sold_table(summary.GrossSaleAmount, summary.CharityDeduction) }}
 
-        {% if summary.AvailUnsoldItems|length > 0 %}
-        <div class="receiptSection col1">
-            <h2>Returned Unsold Items</h2>
-            <table>
-                <tr>
-                    <th class="colA">Title</th>
-                </tr>
-                {% for item in summary.AvailUnsoldItems %}
-                <tr>
-                    <td class="colA">{{item.Title}}</td>
-                </tr>
-                {% endfor %}
-            </table>
-        </div>
-        {% endif %}
+{{ 'Charity contribution is given by the seller after paying out the income to the seller.'|textwrap(40) }}
 
-        {% if summary.DeliveredSoldItems|length > 0 %}
-        <div class="receiptSection col2">
-            <h2>Sales</h2>
-            <table>
-                <tr>
-                    <th class="colA">Title</th>
-                    <th class="colC">Amount</th>
-                </tr>
-                {% for item in summary.DeliveredSoldItems %}
-                <tr>
-                    <td class="colA">{{item.Title}}</td>
-                    <td class="colC">{{item.NetAmount}}€</td>
-                </tr>
-                {% endfor %}
-            </table>
-        </div>
-        {% endif %}
+{% endif -%}
+{% if summary.AvailBoughtItems -%}
+Bought items:
+{{ summary.AvailBoughtItems|bought_table(summary.BoughtItemsAmount) }}
 
+{% endif -%}
+
+Cash:
+{{ summary.TotalDueAmount|cash_table }}
+
+{{ 'By selling and/or buying items in Artshow, buyers and sellers acknowledge that CeSFuR z.s. does not own, sell, or buy any of the items in the Artshow unless written explicitly. Sale agreement is always formed between the seller and the buyer.'|textwrap(40) }}
+
+{% if summary.DeliveredSoldItems -%}
+{{ 'By selling items I agree that CeSFuR z.s. will collect cash from buyers without any commission.'|textwrap(40) }}
+
+{% endif -%}
+{% if summary.AvailBoughtItems -%}
+{{ 'By accepting bought items I agree that CeSFuR z.s. will hand over cash to the seller without any commission. I agree to contact seller directly if further details about the sale is required.'|textwrap(40) }}
+
+{% endif -%}
+This document is not a legal invoice.
+</pre>
     </div>
 </body>
 </html>


### PR DESCRIPTION
This implements ticket #84.

It's formatting the recipie in monospace with the required printer's column width. IMO this makes it easier to develop and test stuff because one cannot know what the browser/printer will do with normal HTML and word wrapping until one printed.

The czech template uses the english template.

It's using a 3rd party module `texttable` for formatting the tables. I included it raw via file because the mechanism for installing python packages seems very complicated in this application. It's only one file after all.

This removes the artshow copy completely, as I understood the ticket. I can re-add it if required.

----
Example with sells and buys:

![recon_all](https://cloud.githubusercontent.com/assets/1580789/26278558/7a29e166-3d9d-11e7-8fac-d5fdb2d64197.PNG)

----
Buys only

![recon_sold_only](https://cloud.githubusercontent.com/assets/1580789/26278556/7a25db02-3d9d-11e7-8029-4edb877ee5c5.PNG)

----
Sells only

![recon_bought_only](https://cloud.githubusercontent.com/assets/1580789/26278557/7a26c238-3d9d-11e7-89a8-420e13fbfa7d.PNG)
